### PR TITLE
make root min-height 100vh

### DIFF
--- a/frontend/src/components/Root/Root.module.css
+++ b/frontend/src/components/Root/Root.module.css
@@ -1,5 +1,5 @@
 .wrapper {
 	display: flex;
 	flex-direction: column;
-	min-height: 100%;
+	min-height: 100vh;
 }


### PR DESCRIPTION
Makes it so the footer is always at the bottom of the browser viewport.

<img width="981" height="739" alt="image" src="https://github.com/user-attachments/assets/123cf066-a59c-4a96-b426-fb849ff63d7b" />
